### PR TITLE
Updates related to electric module

### DIFF
--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -3776,91 +3776,92 @@ class Conductor:
         """
 
         jj = np.r_[ii + 1 : self.total_elements_current_carriers]
-        ll = lmod[jj]
-        mm = lmod[ii]
-        len_jj = self.total_elements_current_carriers - (ii + 1)
-        rr = dict(
-            end_end=np.zeros(len_jj),
-            end_start=np.zeros(len_jj),
-            start_start=np.zeros(len_jj),
-            start_end=np.zeros(len_jj),
-        )
+        # ll = lmod[jj]
+        # mm = lmod[ii]
+        # len_jj = self.total_elements_current_carriers - (ii + 1)
+        # rr = dict(
+        #     end_end=np.zeros(len_jj),
+        #     end_start=np.zeros(len_jj),
+        #     start_start=np.zeros(len_jj),
+        #     start_end=np.zeros(len_jj),
+        # )
 
-        for key in rr.keys():
-            rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
-        # End for key
+        # for key in rr.keys():
+        #     rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
+        # # End for key
 
-        # Additional parameters
-        alpha2 = (
-            rr["start_end"] ** 2
-            - rr["start_start"] ** 2
-            + rr["end_start"] ** 2
-            - rr["end_end"] ** 2
-        )
+        # # Additional parameters
+        # alpha2 = (
+        #     rr["start_end"] ** 2
+        #     - rr["start_start"] ** 2
+        #     + rr["end_start"] ** 2
+        #     - rr["end_end"] ** 2
+        # )
 
-        cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
-        sin_eps = np.sin(np.arccos(cos_eps))
+        # cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
+        # sin_eps = np.sin(np.arccos(cos_eps))
 
-        dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
-        mu = (
-            ll
-            * (
-                2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-                + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-            )
-            / dd
-        )
-        nu = (
-            mm
-            * (
-                2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-                + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-            )
-            / dd
-        )
-        d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
+        # dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
+        # mu = (
+        #     ll
+        #     * (
+        #         2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+        #         + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+        #     )
+        #     / dd
+        # )
+        # nu = (
+        #     mm
+        #     * (
+        #         2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+        #         + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+        #     )
+        #     / dd
+        # )
+        # d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
 
-        # avoid rounding for segments in a plane
-        d2[d2 < abstol ** 2] = 0
-        d0 = np.sqrt(d2)
+        # # avoid rounding for segments in a plane
+        # d2[d2 < abstol ** 2] = 0
+        # d0 = np.sqrt(d2)
 
-        # solid angles
-        omega = (
-            np.arctan(
-                (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
-                / (d0 * rr["end_end"] * sin_eps)
-            )
-            - np.arctan(
-                (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
-                / (d0 * rr["end_start"] * sin_eps)
-            )
-            + np.arctan(
-                (d2 * cos_eps + mu * nu * sin_eps ** 2)
-                / (d0 * rr["start_start"] * sin_eps)
-            )
-            - np.arctan(
-                (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
-                / (d0 * rr["start_end"] * sin_eps)
-            )
-        )
-        omega[d0 == 0.0] = 0.0
+        # # solid angles
+        # omega = (
+        #     np.arctan(
+        #         (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
+        #         / (d0 * rr["end_end"] * sin_eps)
+        #     )
+        #     - np.arctan(
+        #         (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
+        #         / (d0 * rr["end_start"] * sin_eps)
+        #     )
+        #     + np.arctan(
+        #         (d2 * cos_eps + mu * nu * sin_eps ** 2)
+        #         / (d0 * rr["start_start"] * sin_eps)
+        #     )
+        #     - np.arctan(
+        #         (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
+        #         / (d0 * rr["start_end"] * sin_eps)
+        #     )
+        # )
+        # omega[d0 == 0.0] = 0.0
 
-        # contribution
-        pp = np.zeros((len_jj, 5), dtype=float)
-        pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
-        pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
-        pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
-        pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
-        pp[:, 4] = d0 * omega / sin_eps
+        # # contribution
+        # pp = np.zeros((len_jj, 5), dtype=float)
+        # pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
+        # pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
+        # pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
+        # pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
+        # pp[:, 4] = d0 * omega / sin_eps
 
-        # filter odd cases (e.g. consecutive segments)
-        pp[np.isnan(pp)] = 0.0
-        pp[np.isinf(pp)] = 0.0
+        # # filter odd cases (e.g. consecutive segments)
+        # pp[np.isnan(pp)] = 0.0
+        # pp[np.isinf(pp)] = 0.0
 
         # Mutual inductances
         matrix[ii, jj] = (
-            2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
-            - cos_eps * pp[:, 4]
+            5.0e-8 # Mutual inductance imposed by Zappatore input file
+            # 2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
+            # - cos_eps * pp[:, 4]
         )
         return matrix
 
@@ -3920,23 +3921,24 @@ class Conductor:
 
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-               2
-               * lmod[ii :: self.inventory["StrandComponent"].number]
-               * (
-                   np.arcsinh(
-                       lmod[ii :: self.inventory["StrandComponent"].number]
-                       / obj.radius
-                   )
-                   - np.sqrt(
-                       1.0
-                       + (
-                           obj.radius
-                           / lmod[ii :: self.inventory["StrandComponent"].number]
-                       )
-                       ** 2
-                   )
-                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
-               )
+                1.0e-7
+ #               2
+ #               * lmod[ii :: self.inventory["StrandComponent"].number]
+ #               * (
+ #                   np.arcsinh(
+ #                       lmod[ii :: self.inventory["StrandComponent"].number]
+ #                       / obj.radius
+ #                   )
+ #                   - np.sqrt(
+ #                       1.0
+ #                       + (
+ #                           obj.radius
+ #                           / lmod[ii :: self.inventory["StrandComponent"].number]
+ #                       )
+ #                       ** 2
+ #                   )
+ #                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
+ #               )
             )
         return self_inductance
 
@@ -3953,25 +3955,26 @@ class Conductor:
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
 
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-            2 * (
-               lmod[ii :: self.inventory["StrandComponent"].number]
-               * np.log(
-                   (
-                       lmod[ii :: self.inventory["StrandComponent"].number]
-                       + np.sqrt(
-                           lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-                           + obj.radius ** 2
-                       )
-                   )
-                   / obj.radius
-               )
-               - np.sqrt(
-                   lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-                   + obj.radius ** 2
-               )
-               + lmod[ii :: self.inventory["StrandComponent"].number] / 4
-               + obj.radius
-            ))
+                1.0e-7
+#            2 * (
+#                lmod[ii :: self.inventory["StrandComponent"].number]
+#                * np.log(
+#                    (
+#                        lmod[ii :: self.inventory["StrandComponent"].number]
+#                        + np.sqrt(
+#                            lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+#                            + obj.radius ** 2
+#                        )
+#                    )
+#                    / obj.radius
+#                )
+#                - np.sqrt(
+#                    lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+#                    + obj.radius ** 2
+#                )
+#                + lmod[ii :: self.inventory["StrandComponent"].number] / 4
+#                + obj.radius
+            )
 
         return self_inductance
 

--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -3835,92 +3835,91 @@ class Conductor:
         """
 
         jj = np.r_[ii + 1 : self.total_elements_current_carriers]
-        # ll = lmod[jj]
-        # mm = lmod[ii]
-        # len_jj = self.total_elements_current_carriers - (ii + 1)
-        # rr = dict(
-        #     end_end=np.zeros(len_jj),
-        #     end_start=np.zeros(len_jj),
-        #     start_start=np.zeros(len_jj),
-        #     start_end=np.zeros(len_jj),
-        # )
+        ll = lmod[jj]
+        mm = lmod[ii]
+        len_jj = self.total_elements_current_carriers - (ii + 1)
+        rr = dict(
+            end_end=np.zeros(len_jj),
+            end_start=np.zeros(len_jj),
+            start_start=np.zeros(len_jj),
+            start_end=np.zeros(len_jj),
+        )
 
-        # for key in rr.keys():
-        #     rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
-        # # End for key
+        for key in rr.keys():
+            rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
+        # End for key
 
-        # # Additional parameters
-        # alpha2 = (
-        #     rr["start_end"] ** 2
-        #     - rr["start_start"] ** 2
-        #     + rr["end_start"] ** 2
-        #     - rr["end_end"] ** 2
-        # )
+        # Additional parameters
+        alpha2 = (
+            rr["start_end"] ** 2
+            - rr["start_start"] ** 2
+            + rr["end_start"] ** 2
+            - rr["end_end"] ** 2
+        )
 
-        # cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
-        # sin_eps = np.sin(np.arccos(cos_eps))
+        cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
+        sin_eps = np.sin(np.arccos(cos_eps))
 
-        # dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
-        # mu = (
-        #     ll
-        #     * (
-        #         2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-        #         + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-        #     )
-        #     / dd
-        # )
-        # nu = (
-        #     mm
-        #     * (
-        #         2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-        #         + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-        #     )
-        #     / dd
-        # )
-        # d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
+        dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
+        mu = (
+            ll
+            * (
+                2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+                + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+            )
+            / dd
+        )
+        nu = (
+            mm
+            * (
+                2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+                + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+            )
+            / dd
+        )
+        d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
 
-        # # avoid rounding for segments in a plane
-        # d2[d2 < abstol ** 2] = 0
-        # d0 = np.sqrt(d2)
+        # avoid rounding for segments in a plane
+        d2[d2 < abstol ** 2] = 0
+        d0 = np.sqrt(d2)
 
-        # # solid angles
-        # omega = (
-        #     np.arctan(
-        #         (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
-        #         / (d0 * rr["end_end"] * sin_eps)
-        #     )
-        #     - np.arctan(
-        #         (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
-        #         / (d0 * rr["end_start"] * sin_eps)
-        #     )
-        #     + np.arctan(
-        #         (d2 * cos_eps + mu * nu * sin_eps ** 2)
-        #         / (d0 * rr["start_start"] * sin_eps)
-        #     )
-        #     - np.arctan(
-        #         (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
-        #         / (d0 * rr["start_end"] * sin_eps)
-        #     )
-        # )
-        # omega[d0 == 0.0] = 0.0
+        # solid angles
+        omega = (
+            np.arctan(
+                (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
+                / (d0 * rr["end_end"] * sin_eps)
+            )
+            - np.arctan(
+                (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
+                / (d0 * rr["end_start"] * sin_eps)
+            )
+            + np.arctan(
+                (d2 * cos_eps + mu * nu * sin_eps ** 2)
+                / (d0 * rr["start_start"] * sin_eps)
+            )
+            - np.arctan(
+                (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
+                / (d0 * rr["start_end"] * sin_eps)
+            )
+        )
+        omega[d0 == 0.0] = 0.0
 
-        # # contribution
-        # pp = np.zeros((len_jj, 5), dtype=float)
-        # pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
-        # pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
-        # pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
-        # pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
-        # pp[:, 4] = d0 * omega / sin_eps
+        # contribution
+        pp = np.zeros((len_jj, 5), dtype=float)
+        pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
+        pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
+        pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
+        pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
+        pp[:, 4] = d0 * omega / sin_eps
 
-        # # filter odd cases (e.g. consecutive segments)
-        # pp[np.isnan(pp)] = 0.0
-        # pp[np.isinf(pp)] = 0.0
+        # filter odd cases (e.g. consecutive segments)
+        pp[np.isnan(pp)] = 0.0
+        pp[np.isinf(pp)] = 0.0
 
         # Mutual inductances
         matrix[ii, jj] = (
-            5.0e-8 # Mutual inductance imposed by Zappatore input file
-            # 2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
-            # - cos_eps * pp[:, 4]
+            2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
+            - cos_eps * pp[:, 4]
         )
         return matrix
 
@@ -3995,24 +3994,23 @@ class Conductor:
 
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-                1.0e-7
- #               2
- #               * lmod[ii :: self.inventory["StrandComponent"].number]
- #               * (
- #                   np.arcsinh(
- #                       lmod[ii :: self.inventory["StrandComponent"].number]
- #                       / obj.radius
- #                   )
- #                   - np.sqrt(
- #                       1.0
- #                       + (
- #                           obj.radius
- #                           / lmod[ii :: self.inventory["StrandComponent"].number]
- #                       )
- #                       ** 2
- #                   )
- #                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
- #               )
+               2
+               * lmod[ii :: self.inventory["StrandComponent"].number]
+               * (
+                   np.arcsinh(
+                       lmod[ii :: self.inventory["StrandComponent"].number]
+                       / obj.radius
+                   )
+                   - np.sqrt(
+                       1.0
+                       + (
+                           obj.radius
+                           / lmod[ii :: self.inventory["StrandComponent"].number]
+                       )
+                       ** 2
+                   )
+                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
+               )
             )
         return self_inductance
 
@@ -4029,26 +4027,25 @@ class Conductor:
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
 
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-                1.0e-7
-#            2 * (
-#                lmod[ii :: self.inventory["StrandComponent"].number]
-#                * np.log(
-#                    (
-#                        lmod[ii :: self.inventory["StrandComponent"].number]
-#                        + np.sqrt(
-#                            lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-#                            + obj.radius ** 2
-#                        )
-#                    )
-#                    / obj.radius
-#                )
-#                - np.sqrt(
-#                    lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-#                    + obj.radius ** 2
-#                )
-#                + lmod[ii :: self.inventory["StrandComponent"].number] / 4
-#                + obj.radius
-            )
+           2 * (
+               lmod[ii :: self.inventory["StrandComponent"].number]
+               * np.log(
+                   (
+                       lmod[ii :: self.inventory["StrandComponent"].number]
+                       + np.sqrt(
+                           lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+                           + obj.radius ** 2
+                       )
+                   )
+                   / obj.radius
+               )
+               - np.sqrt(
+                   lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+                   + obj.radius ** 2
+               )
+               + lmod[ii :: self.inventory["StrandComponent"].number] / 4
+               + obj.radius
+            ))
 
         return self_inductance
 

--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -3776,91 +3776,92 @@ class Conductor:
         """
 
         jj = np.r_[ii + 1 : self.total_elements_current_carriers]
-        ll = lmod[jj]
-        mm = lmod[ii]
-        len_jj = self.total_elements_current_carriers - (ii + 1)
-        rr = dict(
-            end_end=np.zeros(len_jj),
-            end_start=np.zeros(len_jj),
-            start_start=np.zeros(len_jj),
-            start_end=np.zeros(len_jj),
-        )
+        # ll = lmod[jj]
+        # mm = lmod[ii]
+        # len_jj = self.total_elements_current_carriers - (ii + 1)
+        # rr = dict(
+        #     end_end=np.zeros(len_jj),
+        #     end_start=np.zeros(len_jj),
+        #     start_start=np.zeros(len_jj),
+        #     start_end=np.zeros(len_jj),
+        # )
 
-        for key in rr.keys():
-            rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
-        # End for key
+        # for key in rr.keys():
+        #     rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
+        # # End for key
 
-        # Additional parameters
-        alpha2 = (
-            rr["start_end"] ** 2
-            - rr["start_start"] ** 2
-            + rr["end_start"] ** 2
-            - rr["end_end"] ** 2
-        )
+        # # Additional parameters
+        # alpha2 = (
+        #     rr["start_end"] ** 2
+        #     - rr["start_start"] ** 2
+        #     + rr["end_start"] ** 2
+        #     - rr["end_end"] ** 2
+        # )
 
-        cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
-        sin_eps = np.sin(np.arccos(cos_eps))
+        # cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
+        # sin_eps = np.sin(np.arccos(cos_eps))
 
-        dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
-        mu = (
-            ll
-            * (
-                2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-                + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-            )
-            / dd
-        )
-        nu = (
-            mm
-            * (
-                2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-                + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-            )
-            / dd
-        )
-        d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
+        # dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
+        # mu = (
+        #     ll
+        #     * (
+        #         2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+        #         + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+        #     )
+        #     / dd
+        # )
+        # nu = (
+        #     mm
+        #     * (
+        #         2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+        #         + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+        #     )
+        #     / dd
+        # )
+        # d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
 
-        # avoid rounding for segments in a plane
-        d2[d2 < abstol ** 2] = 0
-        d0 = np.sqrt(d2)
+        # # avoid rounding for segments in a plane
+        # d2[d2 < abstol ** 2] = 0
+        # d0 = np.sqrt(d2)
 
-        # solid angles
-        omega = (
-            np.arctan(
-                (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
-                / (d0 * rr["end_end"] * sin_eps)
-            )
-            - np.arctan(
-                (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
-                / (d0 * rr["end_start"] * sin_eps)
-            )
-            + np.arctan(
-                (d2 * cos_eps + mu * nu * sin_eps ** 2)
-                / (d0 * rr["start_start"] * sin_eps)
-            )
-            - np.arctan(
-                (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
-                / (d0 * rr["start_end"] * sin_eps)
-            )
-        )
-        omega[d0 == 0.0] = 0.0
+        # # solid angles
+        # omega = (
+        #     np.arctan(
+        #         (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
+        #         / (d0 * rr["end_end"] * sin_eps)
+        #     )
+        #     - np.arctan(
+        #         (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
+        #         / (d0 * rr["end_start"] * sin_eps)
+        #     )
+        #     + np.arctan(
+        #         (d2 * cos_eps + mu * nu * sin_eps ** 2)
+        #         / (d0 * rr["start_start"] * sin_eps)
+        #     )
+        #     - np.arctan(
+        #         (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
+        #         / (d0 * rr["start_end"] * sin_eps)
+        #     )
+        # )
+        # omega[d0 == 0.0] = 0.0
 
-        # contribution
-        pp = np.zeros((len_jj, 5), dtype=float)
-        pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
-        pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
-        pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
-        pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
-        pp[:, 4] = d0 * omega / sin_eps
+        # # contribution
+        # pp = np.zeros((len_jj, 5), dtype=float)
+        # pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
+        # pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
+        # pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
+        # pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
+        # pp[:, 4] = d0 * omega / sin_eps
 
-        # filter odd cases (e.g. consecutive segments)
-        pp[np.isnan(pp)] = 0.0
-        pp[np.isinf(pp)] = 0.0
+        # # filter odd cases (e.g. consecutive segments)
+        # pp[np.isnan(pp)] = 0.0
+        # pp[np.isinf(pp)] = 0.0
 
         # Mutual inductances
         matrix[ii, jj] = (
-            2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
-            - cos_eps * pp[:, 4]
+            5.0e-8 # Mutual inductance imposed by Zappatore input file
+            # 2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
+            # - cos_eps * pp[:, 4]
         )
         return matrix
 
@@ -3920,23 +3921,24 @@ class Conductor:
 
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-                2
-                * lmod[ii :: self.inventory["StrandComponent"].number]
-                * (
-                    np.arcsinh(
-                        lmod[ii :: self.inventory["StrandComponent"].number]
-                        / obj.radius
-                    )
-                    - np.sqrt(
-                        1.0
-                        + (
-                            obj.radius
-                            / lmod[ii :: self.inventory["StrandComponent"].number]
-                        )
-                        ** 2
-                    )
-                    + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
-                )
+                1.0e-7
+ #               2
+ #               * lmod[ii :: self.inventory["StrandComponent"].number]
+ #               * (
+ #                   np.arcsinh(
+ #                       lmod[ii :: self.inventory["StrandComponent"].number]
+ #                       / obj.radius
+ #                   )
+ #                   - np.sqrt(
+ #                       1.0
+ #                       + (
+ #                           obj.radius
+ #                           / lmod[ii :: self.inventory["StrandComponent"].number]
+ #                       )
+ #                       ** 2
+ #                   )
+ #                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
+ #               )
             )
         return self_inductance
 
@@ -3952,24 +3954,26 @@ class Conductor:
 
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
 
-            self_inductance[ii :: self.inventory["StrandComponent"].number] = 2 * (
-                lmod[ii :: self.inventory["StrandComponent"].number]
-                * np.log(
-                    (
-                        lmod[ii :: self.inventory["StrandComponent"].number]
-                        + np.sqrt(
-                            lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-                            + obj.radius ** 2
-                        )
-                    )
-                    / obj.radius
-                )
-                - np.sqrt(
-                    lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-                    + obj.radius ** 2
-                )
-                + lmod[ii :: self.inventory["StrandComponent"].number] / 4
-                + obj.radius
+            self_inductance[ii :: self.inventory["StrandComponent"].number] = (
+                1.0e-7
+#            2 * (
+#                lmod[ii :: self.inventory["StrandComponent"].number]
+#                * np.log(
+#                    (
+#                        lmod[ii :: self.inventory["StrandComponent"].number]
+#                        + np.sqrt(
+#                            lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+#                            + obj.radius ** 2
+#                        )
+#                    )
+#                    / obj.radius
+#                )
+#                - np.sqrt(
+#                    lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+#                    + obj.radius ** 2
+#                )
+#                + lmod[ii :: self.inventory["StrandComponent"].number] / 4
+#                + obj.radius
             )
 
         return self_inductance

--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -3776,92 +3776,91 @@ class Conductor:
         """
 
         jj = np.r_[ii + 1 : self.total_elements_current_carriers]
-        # ll = lmod[jj]
-        # mm = lmod[ii]
-        # len_jj = self.total_elements_current_carriers - (ii + 1)
-        # rr = dict(
-        #     end_end=np.zeros(len_jj),
-        #     end_start=np.zeros(len_jj),
-        #     start_start=np.zeros(len_jj),
-        #     start_end=np.zeros(len_jj),
-        # )
+        ll = lmod[jj]
+        mm = lmod[ii]
+        len_jj = self.total_elements_current_carriers - (ii + 1)
+        rr = dict(
+            end_end=np.zeros(len_jj),
+            end_start=np.zeros(len_jj),
+            start_start=np.zeros(len_jj),
+            start_end=np.zeros(len_jj),
+        )
 
-        # for key in rr.keys():
-        #     rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
-        # # End for key
+        for key in rr.keys():
+            rr[key] = self.__vertex_to_vertex_distance(key, ii, jj)
+        # End for key
 
-        # # Additional parameters
-        # alpha2 = (
-        #     rr["start_end"] ** 2
-        #     - rr["start_start"] ** 2
-        #     + rr["end_start"] ** 2
-        #     - rr["end_end"] ** 2
-        # )
+        # Additional parameters
+        alpha2 = (
+            rr["start_end"] ** 2
+            - rr["start_start"] ** 2
+            + rr["end_start"] ** 2
+            - rr["end_end"] ** 2
+        )
 
-        # cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
-        # sin_eps = np.sin(np.arccos(cos_eps))
+        cos_eps = np.minimum(np.maximum(alpha2 / (2 * ll * mm), -1.0), 1.0)
+        sin_eps = np.sin(np.arccos(cos_eps))
 
-        # dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
-        # mu = (
-        #     ll
-        #     * (
-        #         2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-        #         + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-        #     )
-        #     / dd
-        # )
-        # nu = (
-        #     mm
-        #     * (
-        #         2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
-        #         + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
-        #     )
-        #     / dd
-        # )
-        # d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
+        dd = 4 * ll ** 2 * mm ** 2 - alpha2 ** 2
+        mu = (
+            ll
+            * (
+                2 * mm ** 2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+                + alpha2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+            )
+            / dd
+        )
+        nu = (
+            mm
+            * (
+                2 * ll ** 2 * (rr["start_end"] ** 2 - rr["start_start"] ** 2 - mm ** 2)
+                + alpha2 * (rr["end_start"] ** 2 - rr["start_start"] ** 2 - ll ** 2)
+            )
+            / dd
+        )
+        d2 = rr["start_start"] ** 2 - mu ** 2 - nu ** 2 + 2 * mu * nu * cos_eps
 
-        # # avoid rounding for segments in a plane
-        # d2[d2 < abstol ** 2] = 0
-        # d0 = np.sqrt(d2)
+        # avoid rounding for segments in a plane
+        d2[d2 < abstol ** 2] = 0
+        d0 = np.sqrt(d2)
 
-        # # solid angles
-        # omega = (
-        #     np.arctan(
-        #         (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
-        #         / (d0 * rr["end_end"] * sin_eps)
-        #     )
-        #     - np.arctan(
-        #         (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
-        #         / (d0 * rr["end_start"] * sin_eps)
-        #     )
-        #     + np.arctan(
-        #         (d2 * cos_eps + mu * nu * sin_eps ** 2)
-        #         / (d0 * rr["start_start"] * sin_eps)
-        #     )
-        #     - np.arctan(
-        #         (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
-        #         / (d0 * rr["start_end"] * sin_eps)
-        #     )
-        # )
-        # omega[d0 == 0.0] = 0.0
+        # solid angles
+        omega = (
+            np.arctan(
+                (d2 * cos_eps + (mu + ll) * (nu + mm) * sin_eps ** 2)
+                / (d0 * rr["end_end"] * sin_eps)
+            )
+            - np.arctan(
+                (d2 * cos_eps + (mu + ll) * nu * sin_eps ** 2)
+                / (d0 * rr["end_start"] * sin_eps)
+            )
+            + np.arctan(
+                (d2 * cos_eps + mu * nu * sin_eps ** 2)
+                / (d0 * rr["start_start"] * sin_eps)
+            )
+            - np.arctan(
+                (d2 * cos_eps + mu * (nu + mm) * sin_eps ** 2)
+                / (d0 * rr["start_end"] * sin_eps)
+            )
+        )
+        omega[d0 == 0.0] = 0.0
 
-        # # contribution
-        # pp = np.zeros((len_jj, 5), dtype=float)
-        # pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
-        # pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
-        # pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
-        # pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
-        # pp[:, 4] = d0 * omega / sin_eps
+        # contribution
+        pp = np.zeros((len_jj, 5), dtype=float)
+        pp[:, 0] = (ll + mu) * np.arctanh(mm / (rr["end_end"] + rr["end_start"]))
+        pp[:, 1] = -nu * np.arctanh(ll / (rr["end_start"] + rr["start_start"]))
+        pp[:, 2] = (mm + nu) * np.arctanh(ll / (rr["end_end"] + rr["start_end"]))
+        pp[:, 3] = -mu * np.arctanh(mm / (rr["start_start"] + rr["start_end"]))
+        pp[:, 4] = d0 * omega / sin_eps
 
-        # # filter odd cases (e.g. consecutive segments)
-        # pp[np.isnan(pp)] = 0.0
-        # pp[np.isinf(pp)] = 0.0
+        # filter odd cases (e.g. consecutive segments)
+        pp[np.isnan(pp)] = 0.0
+        pp[np.isinf(pp)] = 0.0
 
         # Mutual inductances
         matrix[ii, jj] = (
-            5.0e-8 # Mutual inductance imposed by Zappatore input file
-            # 2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
-            # - cos_eps * pp[:, 4]
+            2 * cos_eps * (pp[:, 0] + pp[:, 1] + pp[:, 2] + pp[:, 3])
+            - cos_eps * pp[:, 4]
         )
         return matrix
 
@@ -3921,24 +3920,23 @@ class Conductor:
 
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-                1.0e-7
- #               2
- #               * lmod[ii :: self.inventory["StrandComponent"].number]
- #               * (
- #                   np.arcsinh(
- #                       lmod[ii :: self.inventory["StrandComponent"].number]
- #                       / obj.radius
- #                   )
- #                   - np.sqrt(
- #                       1.0
- #                       + (
- #                           obj.radius
- #                           / lmod[ii :: self.inventory["StrandComponent"].number]
- #                       )
- #                       ** 2
- #                   )
- #                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
- #               )
+               2
+               * lmod[ii :: self.inventory["StrandComponent"].number]
+               * (
+                   np.arcsinh(
+                       lmod[ii :: self.inventory["StrandComponent"].number]
+                       / obj.radius
+                   )
+                   - np.sqrt(
+                       1.0
+                       + (
+                           obj.radius
+                           / lmod[ii :: self.inventory["StrandComponent"].number]
+                       )
+                       ** 2
+                   )
+                   + obj.radius / lmod[ii :: self.inventory["StrandComponent"].number]
+               )
             )
         return self_inductance
 
@@ -3955,26 +3953,25 @@ class Conductor:
         for ii, obj in enumerate(self.inventory["StrandComponent"].collection):
 
             self_inductance[ii :: self.inventory["StrandComponent"].number] = (
-                1.0e-7
-#            2 * (
-#                lmod[ii :: self.inventory["StrandComponent"].number]
-#                * np.log(
-#                    (
-#                        lmod[ii :: self.inventory["StrandComponent"].number]
-#                        + np.sqrt(
-#                            lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-#                            + obj.radius ** 2
-#                        )
-#                    )
-#                    / obj.radius
-#                )
-#                - np.sqrt(
-#                    lmod[ii :: self.inventory["StrandComponent"].number] ** 2
-#                    + obj.radius ** 2
-#                )
-#                + lmod[ii :: self.inventory["StrandComponent"].number] / 4
-#                + obj.radius
-            )
+            2 * (
+               lmod[ii :: self.inventory["StrandComponent"].number]
+               * np.log(
+                   (
+                       lmod[ii :: self.inventory["StrandComponent"].number]
+                       + np.sqrt(
+                           lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+                           + obj.radius ** 2
+                       )
+                   )
+                   / obj.radius
+               )
+               - np.sqrt(
+                   lmod[ii :: self.inventory["StrandComponent"].number] ** 2
+                   + obj.radius ** 2
+               )
+               + lmod[ii :: self.inventory["StrandComponent"].number] / 4
+               + obj.radius
+            ))
 
         return self_inductance
 

--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -184,7 +184,7 @@ class Conductor:
             "INDUCTANCE_MODE",
             "ELECTRIC_SOLVER",
         ]
-        self.operations.update({key: 1 for key in keys if self.operations[key]})
+        self.operations.update({key: 1 for key in keys if self.operations[key]==True})
         self.operations.update(
             {key: 0 for key in keys if self.operations[key] == False}
         )

--- a/source_code/conductor_flags.py
+++ b/source_code/conductor_flags.py
@@ -16,15 +16,19 @@ ELECTRIC_CONDUCTANCE_UNIT_LENGTH = 1
 # Electric conductance is not defined per unit length
 ELECTRIC_CONDUCTANCE_NOT_UNIT_LENGTH = 2
 
+# Self inductance readed from input file conductor_definition.xlsx
+SELF_INDUCTANCE_MODE_0 = 0
 # Analytical self inductance is evaluated according to mode 1.
 SELF_INDUCTANCE_MODE_1 = 1
 # Analytical self inductance is evaluated according to mode 2.
 SELF_INDUCTANCE_MODE_2 = 2
 
+# Constant mutual inductance readed from input file conductor_definition.xlsx
+CONSTANT_INDUCTANCE = 0
 # Flag to evaluate inductance analytically
-ANALYTICAL_INDUCTANCE = 0
+ANALYTICAL_INDUCTANCE = 1
 # Flag to evaluate inductance using an approximation
-APPROXIMATE_INDUCTANCE = 1
+APPROXIMATE_INDUCTANCE = 2
 
 # Flag to solve the electric problem in steady state conditions.
 STATIC_ELECTRIC_SOLVER = 0

--- a/source_code/properties_of_materials/rare_earth_123.py
+++ b/source_code/properties_of_materials/rare_earth_123.py
@@ -393,7 +393,7 @@ def current_sharing_temperature_re123(B, JOP, TC0M, BC20M, c0):
 
     for _, vv in enumerate(JC_ind):
 
-        T_lower = np.array([3.5])
+        T_lower = np.array([0.5])
         # T_upper = np.array([40.0])
         T_upper = np.array([TC0M])
 

--- a/source_code/properties_of_materials/rare_earth_123.py
+++ b/source_code/properties_of_materials/rare_earth_123.py
@@ -393,7 +393,7 @@ def current_sharing_temperature_re123(B, JOP, TC0M, BC20M, c0):
 
     for _, vv in enumerate(JC_ind):
 
-        T_lower = np.array([0.5])
+        T_lower = np.array([0])
         # T_upper = np.array([40.0])
         T_upper = np.array([TC0M])
 

--- a/source_code/stack_component.py
+++ b/source_code/stack_component.py
@@ -772,7 +772,7 @@ class StackComponent(StrandComponent):
             self.cross_section["sc"] * self.dict_Gauss_pt["J_critical"]
         )
 
-         # Make initialization only once for each conductor object.
+        # Make initialization only once for each conductor object.
         if conductor.cond_num_step == 0:
             # Initialize electric resistance arrays in Gauss point; this is the 
             # equivalent electrical resistance, thus it is defined in this way:
@@ -787,7 +787,7 @@ class StackComponent(StrandComponent):
             self.dict_Gauss_pt["electrical_resistivity_superconductor"] = np.full_like(
                 self.dict_Gauss_pt["temperature"], None
             )
-        
+
         # Get index for which abs(critical_current_gauss) == 0 (inside normal 
         # zone by definition).
         ind_zero = np.nonzero(abs(critical_current_gauss) == 0)[0]
@@ -809,149 +809,40 @@ class StackComponent(StrandComponent):
         # still identify a normal region.
         if ind_not_zero.any():
 
-            # Get index that correspond to superconducting regime.
-            ind_sc_gauss = np.nonzero(
-                self.dict_Gauss_pt["op_current_sc"][ind_not_zero] / critical_current_gauss[ind_not_zero] < 0.95
-            )[0]
-            # Get index that correspond to the normal regime.
-            ind_normal_gauss = np.nonzero(
-                self.dict_Gauss_pt["op_current_sc"][ind_not_zero] / critical_current_gauss[ind_not_zero] >= 0.95
-            )[0]
-
-            ## SUPERCONDUCTING REGIME ##
-
-            # Check if np array ind_sc_gauss is not empty.
-            if ind_sc_gauss.any():
-                # Current in superconducting regime is the carried by
-                # superconducting material only.
-                self.dict_Gauss_pt["op_current"][ind_not_zero[ind_sc_gauss]] = self.dict_Gauss_pt[
-                    "op_current_sc"
-                ][ind_not_zero[ind_sc_gauss]]
-
-                # Compute superconducting electrical resistivity only in index 
-                # for which the superconducting regime is guaranteed, using the 
-                # power low.
-                self.dict_Gauss_pt["electrical_resistivity_superconductor"][ind_not_zero[ind_sc_gauss]] = self.superconductor_power_law(
-                    self.dict_Gauss_pt["op_current"][ind_not_zero[ind_sc_gauss]],
-                    critical_current_gauss[ind_not_zero[ind_sc_gauss]],
-                    self.dict_Gauss_pt["J_critical"][ind_not_zero[ind_sc_gauss]]
+            sc_current_gauss, stab_current_gauss = self.solve_current_divider(
+                self.dict_Gauss_pt["electrical_resistivity_stabilizer"][ind_not_zero],
+                critical_current_gauss[ind_not_zero],
+                self.dict_Gauss_pt["op_current"][ind_not_zero]
                 )
-
-                # Evaluate electic resistance in superconducting region 
-                # (superconductor only).
-                self.dict_Gauss_pt["electric_resistance"][ind_not_zero[
-                    ind_sc_gauss
-                ]] = self.electric_resistance(
-                    conductor, "electrical_resistivity_superconductor", "sc", ind_not_zero[ind_sc_gauss]
+            
+            self.dict_Gauss_pt["electrical_resistivity_superconductor"][
+                ind_not_zero
+            ] = self.superconductor_power_law(
+                sc_current_gauss,
+                critical_current_gauss[ind_not_zero],
+                self.dict_Gauss_pt["J_critical"][ind_not_zero],
                 )
+            # Evaluate the equivalent electric resistance in Ohm.
+            self.dict_Gauss_pt["electric_resistance"][
+                ind_not_zero] = self.parallel_electric_resistance(
+                conductor,
+                [
+                    "electrical_resistivity_superconductor",
+                    "electrical_resistivity_stabilizer",
+                ],["sc","stab"],
+                ind_not_zero,
+            )
 
-            ## NORMAL REGIME ##
-
-            # Check if np array ind_normal_gauss is not empty.
-            if ind_normal_gauss.any():
-                
-                # Evaluate how the current is distributed solving the current
-                # divider problem in Gauss point.
-                sc_current_gauss, stab_current_gauss = self.solve_current_divider(
-                    self.dict_Gauss_pt["electrical_resistivity_stabilizer"][ind_not_zero[ind_normal_gauss]],
-                    critical_current_gauss[ind_not_zero[ind_normal_gauss]],
-                    self.dict_Gauss_pt["op_current"][ind_not_zero[ind_normal_gauss]]
-                )
-
-                # Get index of the normal region where all the current is
-                # carried by the stabilizer, to avoid division by 0 in 
-                # evaluation of superconducting electrical resistivity with the 
-                # power law.
-                ind_stab_gauss = np.nonzero(
-                    (
-                        stab_current_gauss / self.dict_Gauss_pt["op_current"][ind_not_zero[ind_normal_gauss]]
-                        > 0.999999
-                    )
-                    | (sc_current_gauss < 1.0)
-                )[0]
-
-                ## CURRENT CARRIED BY THE STABILIZER ##
-                # Check if np array ind_stab_gauss is not empty.
-                if ind_stab_gauss.any():
-                    # Get the index of location of current sharing region, if 
-                    # any.
-                    ind_sh_gauss = np.nonzero(
-                        (
-                            stab_current_gauss
-                            / self.dict_Gauss_pt["op_current"][ind_not_zero[ind_normal_gauss]]
-                            <= 0.999999
-                        )
-                        | (sc_current_gauss >= 1.0)
-                    )[0]
-                    
-                    # Check if nparray ind_sh_gauss is not empty.
-                    if ind_sh_gauss.any():
-                        # ind_sh_gauss is not empty.
-                        # Get final index of the location of the current 
-                        # sharing zone, keeping into account that 
-                        # sc_current_gauss is already filtered on 
-                        # ind_not_zero[ind_normal_gauss].
-                        ind_shf_gauss = {1:ind_sh_gauss,2:ind_not_zero[ind_normal_gauss[ind_sh_gauss]]}
-                    else:
-                        # ind_sh_gauss is empty.
-                        # Get final index of the location of the current 
-                        # sharing zone, keeping into account that 
-                        # sc_current_gauss is already filtered on 
-                        # ind_not_zero[ind_normal_gauss] and that ind_sh_gauss 
-                        # is empty.
-                        ind_shf_gauss = {1:ind_sh_gauss,2:ind_not_zero[ind_normal_gauss]}
-
-                    # Evaluate electic resistance in normal region (stabilizer 
-                    # only).
-                    self.dict_Gauss_pt["electric_resistance"][
-                        ind_shf_gauss[2]
-                    ] = self.electric_resistance(
-                        conductor, "electrical_resistivity_stabilizer", "stab", ind_shf_gauss[2]
-                    )
-                else:
-                    # Get final index of the location of the current sharing 
-                    # zone, keeping into account that sc_current_gauss is 
-                    # already filtered on ind_not_zero[ind_normal_gauss]. In 
-                    # this case the current is shared between the 
-                    # superconductor and the stabilizer, so we need to exploit 
-                    # all the index in array ind_normal_gauss for the array 
-                    # sc_current_gauss.
-                    ind_shf_gauss = {1:np.nonzero(ind_normal_gauss>=0)[0],2:ind_not_zero[ind_normal_gauss]}
-
-                ## CURRENT SHARED BY THE SUPERCONDUCTOR AND THE STABILIZER ##
-                if ind_shf_gauss[1].any():
-                    # Evaluate the electrical resistivity of the superconductor
-                    # according to the power low in Gauss point in Ohm*m.
-                    self.dict_Gauss_pt["electrical_resistivity_superconductor"][
-                        ind_shf_gauss[2]
-                    ] = self.superconductor_power_law(
-                        sc_current_gauss[ind_shf_gauss[1]],
-                        critical_current_gauss[ind_shf_gauss[2]],
-                        self.dict_Gauss_pt["J_critical"][ind_shf_gauss[2]],
-                    )
-
-                    # Evaluate the equivalent electric resistance in Ohm.
-                    self.dict_Gauss_pt["electric_resistance"][
-                        ind_shf_gauss[2]
-                    ] = self.parallel_electric_resistance(
-                        conductor,
-                        [
-                            "electrical_resistivity_superconductor",
-                            "electrical_resistivity_stabilizer",
-                        ],["sc","stab"],
-                        ind_shf_gauss[2],
-                    )
-                    
-                    # Compute voltage along stabilizer.
-                    v_stab = self.dict_Gauss_pt["electrical_resistivity_stabilizer"][
-                        ind_shf_gauss[2]
-                    ] * stab_current_gauss[ind_shf_gauss[1]] / self.cross_section["stab"]
-                    # Compute voltage along superconductor
-                    v_sc = self.inputs["E0"] * (sc_current_gauss[ind_shf_gauss[1]] / critical_current_gauss[ind_shf_gauss[2]]) ** self.inputs["nn"]
-                    # Check that the voltage along stabilizer is equal to the 
-                    # voltage along superconductor (i.e, check the reliability 
-                    # of the current divider).
-                    if all(np.isclose(v_stab,v_sc)) == False:
-                        raise ValueError(f"Voltage difference along superconductor and stabilizer must be the same.")
+            # Compute voltage along stabilizer.
+            v_stab = self.dict_Gauss_pt["electrical_resistivity_stabilizer"][
+                ind_not_zero
+            ] * stab_current_gauss / self.cross_section["stab"]
+            # Compute voltage along superconductor
+            v_sc = self.inputs["E0"] * (sc_current_gauss / critical_current_gauss[ind_not_zero]) ** self.inputs["nn"]
+            # Check that the voltage along stabilizer is equal to the 
+            # voltage along superconductor (i.e, check the reliability 
+            # of the current divider).
+            if all(np.isclose(v_stab,v_sc)) == False:
+                raise ValueError(f"Voltage difference along superconductor and stabilizer must be the same.")
 
         return self.dict_Gauss_pt["electric_resistance"]

--- a/source_code/strand_mixed_component.py
+++ b/source_code/strand_mixed_component.py
@@ -641,6 +641,19 @@ class StrandMixedComponent(StrandComponent):
                 maxiter=10,
                 disp=False,
             )
+        
+        # Tolerance on newton halley increased in case I_critical is very small,
+        # to avoid inaccuracies on the divider that could lead to potential 
+        # differences between sc and stab
+        if min(critical_current)>1e-6:
+            # Default tollerance in optimize.newton method
+            tollerance = 1.48e-8
+        else:
+            # Value found trial and error iteration
+            tollerance = 1e-12
+            # Other possible solution for the correct tollerance
+            # tollerance = min(critical_current)/1000
+
         # Evaluate superconducting with Halley's method
         sc_current = optimize.newton(
             self.__sc_current_residual,
@@ -648,6 +661,7 @@ class StrandMixedComponent(StrandComponent):
             args=(psi, current),
             fprime=self.__d_sc_current_residual,
             fprime2=self.__d2_sc_current_residual,
+            tol = tollerance,
             maxiter=1000,
         )
 

--- a/source_code/strand_mixed_component.py
+++ b/source_code/strand_mixed_component.py
@@ -797,149 +797,40 @@ class StrandMixedComponent(StrandComponent):
         # still identify a normal region.
         if ind_not_zero.any():
 
-            # Get index that correspond to superconducting regime.
-            ind_sc_gauss = np.nonzero(
-                self.dict_Gauss_pt["op_current_sc"][ind_not_zero] / critical_current_gauss[ind_not_zero] < 0.95
-            )[0]
-            # Get index that correspond to the normal regime.
-            ind_normal_gauss = np.nonzero(
-                self.dict_Gauss_pt["op_current_sc"][ind_not_zero] / critical_current_gauss[ind_not_zero] >= 0.95
-            )[0]
-
-            ## SUPERCONDUCTING REGIME ##
-
-            # Check if np array ind_sc_gauss is not empty.
-            if ind_sc_gauss.any():
-                # Current in superconducting regime is the carried by
-                # superconducting material only.
-                self.dict_Gauss_pt["op_current"][ind_not_zero[ind_sc_gauss]] = self.dict_Gauss_pt[
-                    "op_current_sc"
-                ][ind_not_zero[ind_sc_gauss]]
-
-                # Compute superconducting electrical resistivity only in index 
-                # for which the superconducting regime is guaranteed, using the 
-                # power low.
-                self.dict_Gauss_pt["electrical_resistivity_superconductor"][ind_not_zero[ind_sc_gauss]] = self.superconductor_power_law(
-                    self.dict_Gauss_pt["op_current"][ind_not_zero[ind_sc_gauss]],
-                    critical_current_gauss[ind_not_zero[ind_sc_gauss]],
-                    self.dict_Gauss_pt["J_critical"][ind_not_zero[ind_sc_gauss]]
+            sc_current_gauss, stab_current_gauss = self.solve_current_divider(
+                self.dict_Gauss_pt["electrical_resistivity_stabilizer"][ind_not_zero],
+                critical_current_gauss[ind_not_zero],
+                self.dict_Gauss_pt["op_current"][ind_not_zero]
                 )
-
-                # Evaluate electic resistance in superconducting region 
-                # (superconductor only).
-                self.dict_Gauss_pt["electric_resistance"][ind_not_zero[
-                    ind_sc_gauss
-                ]] = self.electric_resistance(
-                    conductor, "electrical_resistivity_superconductor", "sc", ind_not_zero[ind_sc_gauss]
+            
+            self.dict_Gauss_pt["electrical_resistivity_superconductor"][
+                ind_not_zero
+            ] = self.superconductor_power_law(
+                sc_current_gauss,
+                critical_current_gauss[ind_not_zero],
+                self.dict_Gauss_pt["J_critical"][ind_not_zero],
                 )
+            # Evaluate the equivalent electric resistance in Ohm.
+            self.dict_Gauss_pt["electric_resistance"][
+                ind_not_zero] = self.parallel_electric_resistance(
+                conductor,
+                [
+                    "electrical_resistivity_superconductor",
+                    "electrical_resistivity_stabilizer",
+                ],["sc","stab"],
+                ind_not_zero,
+            )
 
-            ## NORMAL REGIME ##
-
-            # Check if np array ind_normal_gauss is not empty.
-            if ind_normal_gauss.any():
-
-                # Evaluate how the current is distributed solving the current
-                # divider problem in Gauss point.
-                sc_current_gauss, stab_current_gauss = self.solve_current_divider(
-                    self.dict_Gauss_pt["electrical_resistivity_stabilizer"][ind_not_zero[ind_normal_gauss]],
-                    critical_current_gauss[ind_not_zero[ind_normal_gauss]],
-                    self.dict_Gauss_pt["op_current"][ind_not_zero[ind_normal_gauss]]
-                )
-
-                # Get index of the normal region where all the current is
-                # carried by the stabilizer, to avoid division by 0 in 
-                # evaluation of superconducting electrical resistivity with the 
-                # power law.
-                ind_stab_gauss = np.nonzero(
-                    (
-                        stab_current_gauss / self.dict_Gauss_pt["op_current"][ind_not_zero[ind_normal_gauss]]
-                        > 0.999999
-                    )
-                    | (sc_current_gauss < 1.0)
-                )[0]
-
-                ## CURRENT CARRIED BY THE STABILIZER ##
-                # Check if np array ind_stab_gauss is not empty.
-                if ind_stab_gauss.any():
-                    # Get the index of location of current sharing region, if 
-                    # any.
-                    ind_sh_gauss = np.nonzero(
-                        (
-                            stab_current_gauss
-                            / self.dict_Gauss_pt["op_current"][ind_not_zero[ind_normal_gauss]]
-                            <= 0.999999
-                        )
-                        | (sc_current_gauss >= 1.0)
-                    )[0]
-                    
-                    # Check if nparray ind_sh_gauss is not empty.
-                    if ind_sh_gauss.any():
-                        # ind_sh_gauss is not empty.
-                        # Get final index of the location of the current 
-                        # sharing zone, keeping into account that 
-                        # sc_current_gauss is already filtered on 
-                        # ind_not_zero[ind_normal_gauss].
-                        ind_shf_gauss = {1:ind_sh_gauss,2:ind_not_zero[ind_normal_gauss[ind_sh_gauss]]}
-                    else:
-                        # ind_sh_gauss is empty.
-                        # Get final index of the location of the current 
-                        # sharing zone, keeping into account that 
-                        # sc_current_gauss is already filtered on 
-                        # ind_not_zero[ind_normal_gauss] and that ind_sh_gauss 
-                        # is empty.
-                        ind_shf_gauss = {1:ind_sh_gauss,2:ind_not_zero[ind_normal_gauss]}
-
-                    # Evaluate electic resistance in normal region (stabilizer 
-                    # only).
-                    self.dict_Gauss_pt["electric_resistance"][
-                        ind_shf_gauss[2]
-                    ] = self.electric_resistance(
-                        conductor, "electrical_resistivity_stabilizer", "stab", ind_shf_gauss[2]
-                    )
-                else:
-                    # Get final index of the location of the current sharing 
-                    # zone, keeping into account that sc_current_gauss is 
-                    # already filtered on ind_not_zero[ind_normal_gauss]. In 
-                    # this case the current is shared between the 
-                    # superconductor and the stabilizer, so we need to exploit 
-                    # all the index in array ind_normal_gauss for the array 
-                    # sc_current_gauss.
-                    ind_shf_gauss = {1:np.nonzero(ind_normal_gauss>=0)[0],2:ind_not_zero[ind_normal_gauss]}
-
-                ## CURRENT SHARED BY THE SUPERCONDUCTOR AND THE STABILIZER ##
-                if ind_shf_gauss[1].any():
-                    # Evaluate the electrical resistivity of the superconductor
-                    # according to the power low in Gauss point in Ohm*m.
-                    self.dict_Gauss_pt["electrical_resistivity_superconductor"][
-                        ind_shf_gauss[2]
-                    ] = self.superconductor_power_law(
-                        sc_current_gauss[ind_shf_gauss[1]],
-                        critical_current_gauss[ind_shf_gauss[2]],
-                        self.dict_Gauss_pt["J_critical"][ind_shf_gauss[2]],
-                    )
-
-                    # Evaluate the equivalent electric resistance in Ohm.
-                    self.dict_Gauss_pt["electric_resistance"][
-                        ind_shf_gauss[2]
-                    ] = self.parallel_electric_resistance(
-                        conductor,
-                        [
-                            "electrical_resistivity_superconductor",
-                            "electrical_resistivity_stabilizer",
-                        ],["sc","stab"],
-                        ind_shf_gauss[2],
-                    )
-                    
-                    # Compute voltage along stabilizer.
-                    v_stab = self.dict_Gauss_pt["electrical_resistivity_stabilizer"][
-                        ind_shf_gauss[2]
-                    ] * stab_current_gauss[ind_shf_gauss[1]] / self.cross_section["stab"]
-                    # Compute voltage along superconductor
-                    v_sc = self.inputs["E0"] * (sc_current_gauss[ind_shf_gauss[1]] / critical_current_gauss[ind_shf_gauss[2]]) ** self.inputs["nn"]
-                    # Check that the voltage along stabilizer is equal to the 
-                    # voltage along superconductor (i.e, check the reliability 
-                    # of the current divider).
-                    if all(np.isclose(v_stab,v_sc)) == False:
-                        raise ValueError(f"Voltage difference along superconductor and stabilizer must be the same.")
+            # Compute voltage along stabilizer.
+            v_stab = self.dict_Gauss_pt["electrical_resistivity_stabilizer"][
+                ind_not_zero
+            ] * stab_current_gauss / self.cross_section["stab"]
+            # Compute voltage along superconductor
+            v_sc = self.inputs["E0"] * (sc_current_gauss / critical_current_gauss[ind_not_zero]) ** self.inputs["nn"]
+            # Check that the voltage along stabilizer is equal to the 
+            # voltage along superconductor (i.e, check the reliability 
+            # of the current divider).
+            if all(np.isclose(v_stab,v_sc)) == False:
+                raise ValueError(f"Voltage difference along superconductor and stabilizer must be the same.")
 
         return self.dict_Gauss_pt["electric_resistance"]


### PR DESCRIPTION
1) Updated the Class StackComponent, with the same idea behind the Class StrandMixedComponent.

2) Fixed the lower limit for the bisection method in the method current_sharing_temperature_re123. This limit is now set to 0 to avoid error given by bisection method.

3) Refactor of the method get_electric_resistance, both in Class StrandMixedComponent and in Class StackComponent. All the previous indices are eliminated and now there are only two cases:
a) if critical_current = 0 the equivalent resistance is equal to the stabilizer resistance
b) if critical_current is not = 0 then the current divider is used.

4) Inside the Class Conductor many chages were made to permitt a constant value of the mutual inductance and the self inductance set by the user in the input file conductor_definition.xlsx, in sheet CONDUCTOR_operation.

5) To avoid the ValueError that arises in the check on the voltage along stabilizer that must be equal to the voltage along superconductor, the tollerance in the method solve_current_divider, in the Class StrandMixedComponent, is modified when the minimum in the vector critical_current is below a certain value. This change has been verified.