### PR TITLE
New update in the electric module

### DIFF
--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -4321,6 +4321,12 @@ class Conductor:
                 ii :: self.inventory["StrandComponent"].number
             ]
 
+            obj.dict_node_pt["current_along"] = np.interp(
+                        self.grid_features["zcoord"],
+                        self.grid_features["zcoord_gauss"],
+                        obj.dict_Gauss_pt["current_along"]
+                        )
+
             obj.dict_Gauss_pt["delta_voltage_along"] = delta_voltage_along[
                 ii :: self.inventory["StrandComponent"].number
             ]
@@ -4881,7 +4887,7 @@ class Conductor:
             else:
                 # Update only electrical resistivity (stabilizer) at each 
                 # electric time step.
-                if isinstance(strand,StrandMixedComponent):
+                if isinstance(strand,StrandMixedComponent) or isinstance(strand,StackComponent):
                     strand.dict_node_pt["electrical_resistivity_stabilizer"] = strand.strand_electrical_resistivity_not_sc(
                             strand.dict_node_pt
                         )

--- a/source_code/conductor.py
+++ b/source_code/conductor.py
@@ -4887,9 +4887,13 @@ class Conductor:
             else:
                 # Update only electrical resistivity (stabilizer) at each 
                 # electric time step.
-                if isinstance(strand,StrandMixedComponent) or isinstance(strand,StackComponent):
+                if isinstance(strand,StrandMixedComponent):
                     strand.dict_node_pt["electrical_resistivity_stabilizer"] = strand.strand_electrical_resistivity_not_sc(
                             strand.dict_node_pt
+                        )
+                elif isinstance(strand, StackComponent):
+                    strand.dict_Gauss_pt["electrical_resistivity_stabilizer"] = strand.stack_electrical_resistivity_not_sc(
+                        strand.dict_Gauss_pt
                         )
                 elif isinstance(strand, StrandStabilizerComponent):
                     strand.dict_node_pt["electrical_resistivity_stabilizer"] = strand.strand_electrical_resistivity(
@@ -4979,7 +4983,11 @@ class Conductor:
                 # electric time step.
                 if isinstance(strand,StrandMixedComponent):
                     strand.dict_Gauss_pt["electrical_resistivity_stabilizer"] = strand.strand_electrical_resistivity_not_sc(
-                            strand.dict_Gauss_pt
+                        strand.dict_Gauss_pt
+                        )
+                elif isinstance(strand, StackComponent):
+                    strand.dict_Gauss_pt["electrical_resistivity_stabilizer"] = strand.stack_electrical_resistivity_not_sc(
+                        strand.dict_Gauss_pt
                         )
                 elif isinstance(strand, StrandStabilizerComponent):
                     strand.dict_Gauss_pt["electrical_resistivity_stabilizer"] = strand.strand_electrical_resistivity(

--- a/source_code/solid_component.py
+++ b/source_code/solid_component.py
@@ -267,6 +267,10 @@ class SolidComponent:
                     self.dict_Gauss_pt["op_current_sc"] = self.dict_Gauss_pt[
                         "op_current"
                     ]
+                if conductor.cond_time[-1] == 0:
+                    self.dict_node_pt["current_along"] = self.dict_node_pt["op_current"]
+                    self.dict_Gauss_pt["current_along"] = self.dict_Gauss_pt["op_current"]
+
 
                 if self.flagSpecfield_current == 2:
                     # Add also a logger
@@ -297,6 +301,9 @@ class SolidComponent:
                         self.dict_node_pt["op_current_sc"][:-1]
                         + self.dict_node_pt["op_current_sc"][1:]
                     ) / 2.0
+                if conductor.cond_time[-1] == 0:
+                    self.dict_node_pt["current_along"] = self.dict_node_pt["op_current"]
+                    self.dict_Gauss_pt["current_along"] = self.dict_Gauss_pt["op_current"]
 
             elif conductor.inputs["I0_OP_MODE"] == IOP_NOT_DEFINED:
                 # User does not specify a current: set current carrient 

--- a/source_code/stack_component.py
+++ b/source_code/stack_component.py
@@ -523,6 +523,34 @@ class StackComponent(StrandComponent):
             axis=1
         ) / self.tape_thickness
 
+    # def stack_electrical_resistivity_not_sc(self, property: dict) -> np.ndarray:
+    #     """Method that evaluates the homogenized electrical resistivity for not superconducting materials of the stack, which is the same of the tape if the tapes constituting the stack are equals to each other. Homogenization is based on the thickness of tape layers.
+
+    #     Args:
+    #         property (dict): dictionary with material properties in nodal points or Gauss points according to the value of flag nodal in method eval_sol_comp_properties of class SolidComponent.
+
+    #     Returns:
+    #         np.ndarray: array with homogenized electrical resistivity of not superconducting materials of the stack of tapes in Ohm*m.
+    #     """
+    #     electrical_resistivity = np.zeros(
+    #         (property["temperature"].size, self.inputs["Material_number"] - 1)
+    #     )
+    #     for ii, func in enumerate(self.electrical_resistivity_function_not_sc):
+    #         if "cu" in func.__name__:
+    #             electrical_resistivity[:, ii] = func(
+    #                 property["temperature"],
+    #                 property["B_field"],
+    #                 self.inputs["RRR"],
+    #             )
+    #         else:
+    #             electrical_resistivity[:, ii] = func(property["temperature"])
+    #     if self.inputs["Material_number"] - 1 > 1:
+    #         # Evaluate homogenized electrical resistivity of the stack:
+    #         # rho_el_eq = A_not_sc * (sum(A_i/rho_el_i))^-1 for any i not sc
+    #         return self.cross_section["stab_sloped"] * np.reciprocal((self.cross_section["stab_sloped"] / electrical_resistivity).sum(axis=1))
+    #     elif self.inputs["Material_number"] - 1 == 1:
+    #         return electrical_resistivity.reshape(property["temperature"].size)
+
     def stack_electrical_resistivity_not_sc(self, property: dict) -> np.ndarray:
         """Method that evaluates the homogenized electrical resistivity for not superconducting materials of the stack, which is the same of the tape if the tapes constituting the stack are equals to each other. Homogenization is based on the thickness of tape layers.
 
@@ -547,7 +575,10 @@ class StackComponent(StrandComponent):
         if self.inputs["Material_number"] - 1 > 1:
             # Evaluate homogenized electrical resistivity of the stack:
             # rho_el_eq = A_not_sc * (sum(A_i/rho_el_i))^-1 for any i not sc
-            return self.cross_section["stab_sloped"] * np.reciprocal((self.cross_section["stab_sloped"] / electrical_resistivity).sum(axis=1))
+            # In this case becomes rho_el_eq = t_not_sc * (sum(t_i/rho_el_i))^-1 where t is the thickness
+            
+            return self.tape_thickness_not_sc * np.reciprocal((
+                self.material_thickness_not_sc / electrical_resistivity).sum(axis=1))
         elif self.inputs["Material_number"] - 1 == 1:
             return electrical_resistivity.reshape(property["temperature"].size)
 

--- a/source_code/stack_component.py
+++ b/source_code/stack_component.py
@@ -657,6 +657,18 @@ class StackComponent(StrandComponent):
                 disp=False,
             )
 
+        # Tolerance on newton halley increased in case I_critical is very small,
+        # to avoid inaccuracies on the divider that could lead to potential 
+        # differences between sc and stab
+        if min(critical_current)>1e-6:
+            # Default tollerance in optimize.newton method
+            tollerance = 1.48e-8
+        else:
+            # Value found trial and error iteration
+            # tollerance = 1e-12
+            # Other possible solution for the correct tollerance
+            tollerance = min(critical_current)/1000
+        
         # Evaluate superconducting with Halley's method
         sc_current = optimize.newton(
             self.__sc_current_residual,
@@ -664,6 +676,7 @@ class StackComponent(StrandComponent):
             args=(psi, current),
             fprime=self.__d_sc_current_residual,
             fprime2=self.__d2_sc_current_residual,
+            tol = tollerance,
             maxiter=1000,
         )
 

--- a/source_code/stack_component.py
+++ b/source_code/stack_component.py
@@ -523,34 +523,6 @@ class StackComponent(StrandComponent):
             axis=1
         ) / self.tape_thickness
 
-    # def stack_electrical_resistivity_not_sc(self, property: dict) -> np.ndarray:
-    #     """Method that evaluates the homogenized electrical resistivity for not superconducting materials of the stack, which is the same of the tape if the tapes constituting the stack are equals to each other. Homogenization is based on the thickness of tape layers.
-
-    #     Args:
-    #         property (dict): dictionary with material properties in nodal points or Gauss points according to the value of flag nodal in method eval_sol_comp_properties of class SolidComponent.
-
-    #     Returns:
-    #         np.ndarray: array with homogenized electrical resistivity of not superconducting materials of the stack of tapes in Ohm*m.
-    #     """
-    #     electrical_resistivity = np.zeros(
-    #         (property["temperature"].size, self.inputs["Material_number"] - 1)
-    #     )
-    #     for ii, func in enumerate(self.electrical_resistivity_function_not_sc):
-    #         if "cu" in func.__name__:
-    #             electrical_resistivity[:, ii] = func(
-    #                 property["temperature"],
-    #                 property["B_field"],
-    #                 self.inputs["RRR"],
-    #             )
-    #         else:
-    #             electrical_resistivity[:, ii] = func(property["temperature"])
-    #     if self.inputs["Material_number"] - 1 > 1:
-    #         # Evaluate homogenized electrical resistivity of the stack:
-    #         # rho_el_eq = A_not_sc * (sum(A_i/rho_el_i))^-1 for any i not sc
-    #         return self.cross_section["stab_sloped"] * np.reciprocal((self.cross_section["stab_sloped"] / electrical_resistivity).sum(axis=1))
-    #     elif self.inputs["Material_number"] - 1 == 1:
-    #         return electrical_resistivity.reshape(property["temperature"].size)
-
     def stack_electrical_resistivity_not_sc(self, property: dict) -> np.ndarray:
         """Method that evaluates the homogenized electrical resistivity for not superconducting materials of the stack, which is the same of the tape if the tapes constituting the stack are equals to each other. Homogenization is based on the thickness of tape layers.
 

--- a/source_code/stack_component.py
+++ b/source_code/stack_component.py
@@ -658,8 +658,9 @@ class StackComponent(StrandComponent):
             )
 
         # Tolerance on newton halley increased in case I_critical is very small,
-        # to avoid inaccuracies on the divider that could lead to potential 
-        # differences between sc and stab
+        # to avoid inaccuracies on the divider that could lead to voltage 
+        # differences between sc and stab that are not expected in the parallel
+        # of electric resistances.
         if min(critical_current)>1e-6:
             # Default tollerance in optimize.newton method
             tollerance = 1.48e-8
@@ -667,7 +668,7 @@ class StackComponent(StrandComponent):
             # Value found trial and error iteration
             # tollerance = 1e-12
             # Other possible solution for the correct tollerance
-            tollerance = min(critical_current)/1000
+            tollerance = min(critical_current)/1e3
         
         # Evaluate superconducting with Halley's method
         sc_current = optimize.newton(

--- a/source_code/strand_component.py
+++ b/source_code/strand_component.py
@@ -270,7 +270,7 @@ class StrandComponent(SolidComponent):
         # evaluation of the current densities the total superconducting 
         # perpendicular cross section is always used.
         jop = (
-            np.abs(dict_dummy["op_current"])
+            np.abs(dict_dummy["current_along"])
             / (self.cross_section["sc"])
         )
 


### PR DESCRIPTION
Inside StackComponent:
- Parallel calculation of electrical resistivities for stack class not-sc materials correctly implemented according to the formula: rho_el_eq = A_not_sc * (sum(A_i/rho_el_i))^-1. 
- Added a change to the accepted tolerance for calculating the current divider between sc and not-sc, to avoid later errors in checking the voltage differences seen on the sc-side and not-sc-side, which is present in certain case studies. 
- Added check that solid component object is an istance of StackComponent exploiting function isistance in operating_conditions_em and in __eval_gauss_point_em in conductor.py. This is done to guarantee that all the properties of meterials are correctly updated at each time step for all solid component object.
- Changed definition of operating current density for calculation of current sharing temperature. Where previously the ratio of total operating current divided by the strand cross section was considered, now the actual fraction of current sharing within the strand is considered. To do this was necessary to initialise the current _along value equal to op_current value for the first time step inside method get_current , and to change the computation of jop inside method eval_tcs in strand.py.